### PR TITLE
correct dependency url

### DIFF
--- a/src/bower.json
+++ b/src/bower.json
@@ -23,7 +23,7 @@
         "jquery-timeago": "1.4.0",
         "jquery-yql": "https://raw.githubusercontent.com/hail2u/jquery.query-yql/655264551b7962485bcf0d06226e053a6f24629b/jquery.query-yql.js",
         "jsbn": "1.3.0",
-        "knockoutjs": "http://knockoutjs.com/downloads/knockout-3.1.0.js",
+        "knockoutjs": "https://raw.githubusercontent.com/knockout/knockout/v3.1.0/dist/knockout.js",
         "knockout-secure-binding": "0.4.4",
         "knockout-bootstrap": "0.2.1",
         "knockout-validation": "1.0.2",


### PR DESCRIPTION
knockoutjs existing source has an invalid ssl certificate preventing compilation with bower, this updates it to a place with an active ssl certificate.